### PR TITLE
Empty blocks on empty stdout

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -8,5 +8,9 @@ set -euo pipefail
 profile=$(nix-build --no-out-link profile.nix)
 export PATH=$profile/bin:$PATH
 
+# first, check formatting
+# everything after -- is passed to rustfmt
+cargo fmt -- --check
+
 cargo build
 cargo test

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,16 +219,20 @@ fn main() -> std::io::Result<()> {
                 eprintln!("{} {}", command_char, command);
 
                 let result = run_command(command, &work_dir);
-
                 if result.status.success() {
                     let stdout = String::from_utf8_lossy(&result.stdout);
-                    format!(
-                        "{}{}{}{}",
-                        trail_nl(&caps[0]),
-                        start_delimiter,
-                        wrap_nl(stdout.to_string()),
-                        end_delimiter
-                    )
+                    // we can leave the output block if stdout was empty
+                    if stdout.trim().is_empty() {
+                        format!("{}", trail_nl(&caps[0]))
+                    } else {
+                        format!(
+                            "{}{}{}{}",
+                            trail_nl(&caps[0]),
+                            start_delimiter,
+                            wrap_nl(stdout.to_string()),
+                            end_delimiter
+                        )
+                    }
                 } else {
                     failures.push(FailingCommand {
                         output: result,

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,9 @@ fn run_command(command: &str, work_dir: &Parent) -> Output {
 }
 
 fn die<A>(msg: String) -> A {
-    std::io::stderr().write_all(format!("fatal: {}\n", msg).as_bytes()).unwrap();
+    std::io::stderr()
+        .write_all(format!("fatal: {}\n", msg).as_bytes())
+        .unwrap();
     std::process::exit(1)
 }
 
@@ -42,13 +44,20 @@ fn read_file(f: &FileArg) -> String {
         FileArg::StdHandle => {
             let stdin = io::stdin();
             let mut handle = stdin.lock();
-            handle.read_to_string(&mut buffer)
+            handle
+                .read_to_string(&mut buffer)
                 .unwrap_or_else(|err| die(format!("failed to read from stdin: {}", err)));
         }
         FileArg::File(path_buf) => {
             File::open(path_buf)
                 .and_then(|mut file| file.read_to_string(&mut buffer))
-                .unwrap_or_else(|err| die(format!("failed to read from {}: {}", path_buf.display(), err)));
+                .unwrap_or_else(|err| {
+                    die(format!(
+                        "failed to read from {}: {}",
+                        path_buf.display(),
+                        err
+                    ))
+                });
         }
     }
 
@@ -69,7 +78,13 @@ fn write_file(f: &FileArg, contents: String) {
                     write!(file, "{}", contents)?;
                     file.sync_all()
                 })
-                .unwrap_or_else(|err| die(format!("failed to write to {}: {}", path_buf.display(), err)));
+                .unwrap_or_else(|err| {
+                    die(format!(
+                        "failed to write to {}: {}",
+                        path_buf.display(),
+                        err
+                    ))
+                });
         }
     }
 }


### PR DESCRIPTION
We can leave out empty blocks if command don’t return anything on stdout.

This also adds the formatting I forgot in the last command and adds a check to travis so that it can’t happen again.