### PR TITLE
Small fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "mdsh"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "difference",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdsh"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["zimbatm <zimbatm@zimbatm.com>"]
 edition = "2018"
 description = "Markdown shell pre-processor"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ file and in exchange it allows to automate the refresh of those outputs.
 `$ mdsh --help`
 
 ```
-mdsh 0.8.0
+mdsh 0.8.1
 Markdown shell pre-processor. Never let your READMEs and tutorials get out of sync again.
 
 Exits non-zero if a sub-command failed.

--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,9 @@
     in
     {
       devShell = import ./shell.nix { inherit pkgs; };
-      packages.default = pkgs.rustPlatform.buildRustPackage rec {
+      packages.default = pkgs.rustPlatform.buildRustPackage {
         pname = "mdsh";
-        version = "0.8.0";
+        version = "0.8.1";
 
         src = fs.toSource {
           root = ./.;
@@ -22,12 +22,11 @@
             fs.unions [
               ./Cargo.toml
               ./Cargo.lock
-              ./README.md
               ./src
             ];
         };
 
-        cargoSha256 = "sha256-irbEkKJyLmQry/dBY92kAsfpyHx1a7XumLYWiLU99mY=";
+        cargoSha256 = "sha256-Barf/CRt5LYtIxUigBZNwiJwVmmEjCKm2lbp+ww2sBs=";
 
         meta = with lib; {
           description = "Markdown shell pre-processor";

--- a/shell.nix
+++ b/shell.nix
@@ -12,5 +12,6 @@ pkgs.mkShell {
 
   shellHook = ''
     export PATH=$PWD/target/debug:$PATH
+    export RUST_SRC_PATH="${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
   '';
 }


### PR DESCRIPTION
- Fix default devshell
  - set `RUST_SRC_PATH` to make `rust-analyzer` work ([link](https://discourse.nixos.org/t/rust-src-not-found-and-other-misadventures-of-developing-rust-on-nixos/11570/5))

- Fix error printing.
  - Now multiline commands are printed in multiline blocks

~~~
ERROR: some commands failed:

```
se 3 | sort -r
seq 2 | sort -r
```
failed with exit status: 127.
Its stderr was:
bash: line 1: se: command not found

`$ ech hello $user`
failed with exit status: 127.
Its stderr was:
bash: line 1: ech: command not found
~~~

- Bump version
- Update derivation

cc @zimbatm 