### PR TITLE
fix: add `--version` back

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 ///
 /// Exits non-zero if a sub-command failed.
 #[derive(Debug, Parser)]
-#[clap(name = "mdsh")]
+#[clap(name = "mdsh", version = env!("CARGO_PKG_VERSION"))]
 pub struct Opt {
     /// Path to the markdown files. `-` for stdin.
     #[clap(


### PR DESCRIPTION
with https://github.com/zimbatm/mdsh/pull/75 update, now the --version is missing, update to add it back

relates to https://github.com/Homebrew/homebrew-core/pull/210933