### PR TITLE
Fix `mdsh -i <file> <file>` not working

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,8 @@ pub struct Opt {
         short = 'i',
         long = "inputs",
         alias = "input",
-        default_value = "./README.md"
+        default_value = "./README.md",
+        num_args = 1..,
     )]
     pub inputs: Vec<FileArg>,
 


### PR DESCRIPTION
`-i` is documented as 

```
  -i, --inputs <INPUTS>
          Path to the markdown files. `-` for stdin
```