### PR TITLE
Fix in-place processing dropping lines from files without mdsh tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,36 @@ These slightly deviate from the rest of containers:
 [<out_cmd> <in_cmd> whatever here is ignored](<data_line>)
 ```
 
+## Transition text
+
+You can insert text between the mdsh invocation and its generated output by appending `:: text` to the command. 
+This works in all container types, but is most useful in a code block. 
+For example:
+
+````md
+```sh > sh $ :: which outputs:
+echo 'hello world'
+```
+````
+
+results in:
+
+````md
+```sh > sh $ :: which outputs:
+echo 'hello world'
+```
+
+<!-- BEGIN mdsh -->
+which outputs:
+
+```sh
+hello world
+```
+<!-- END mdsh --
+````
+
+When rendered, this shows the command, the transition ("which outputs:"), and the output supporting a natural reading flow.
+
 ## Installation
 
 The best way to install `mdsh` is with the rust tool cargo.

--- a/README.md
+++ b/README.md
@@ -160,8 +160,7 @@ These slightly deviate from the rest of containers:
 
 ## Transition text
 
-You can insert text between the mdsh invocation and its generated output by appending `:: text` to the command. 
-This works in all container types, but is most useful in a code block. 
+You can insert text between an `mdsh` invocation and its output by appending `:: text` to the command. 
 For example:
 
 ````md
@@ -170,13 +169,9 @@ echo 'hello world'
 ```
 ````
 
-results in:
+produces:
 
 ````md
-```sh > sh $ :: which outputs:
-echo 'hello world'
-```
-
 <!-- BEGIN mdsh -->
 which outputs:
 
@@ -186,7 +181,25 @@ hello world
 <!-- END mdsh --
 ````
 
-When rendered, this shows the command, the transition ("which outputs:"), and the output supporting a natural reading flow.
+When rendered, the command code block, the transition text, and the output block support a natural reading flow.
+
+You may also add the transition text as a comment following an `mdsh` invocation.
+For example:
+
+````md
+`> $ echo hi`
+<!-- :: outputs -->
+````
+
+produces:
+
+````md
+<!-- BEGIN mdsh -->
+outputs
+
+hi
+<!-- END mdsh -->
+````
 
 ## Installation
 

--- a/spec.clear.md
+++ b/spec.clear.md
@@ -18,6 +18,8 @@ in `spec.clear.md` must correspond to the same section in `spec.processed.md`.
     - [Executing command in multiline comments with data line and producing raw markdown](#executing-command-in-multiline-comments-with-data-line-and-producing-raw-markdown)
     - [Executing command in multiline comments and producing raw markdown](#executing-command-in-multiline-comments-and-producing-raw-markdown)
     - [Executing command in markdown link and producing raw markdown](#executing-command-in-markdown-link-and-producing-raw-markdown)
+    - [Code block with transition producing raw markdown](#code-block-with-transition-producing-raw-markdown)
+    - [Inline code with transition as a comment producing raw markdown](#inline-code-with-transition-as-a-comment-producing-raw-markdown)
   - [Reading files contents](#reading-files-contents)
     - [Reading file in inline code and producing raw markdown](#reading-file-in-inline-code-and-producing-raw-markdown)
     - [Reading file in code blocks and producing raw markdown](#reading-file-in-code-blocks-and-producing-raw-markdown)
@@ -34,6 +36,7 @@ in `spec.clear.md` must correspond to the same section in `spec.processed.md`.
     - [Executing command in multiline comments with data line and producing code block](#executing-command-in-multiline-comments-with-data-line-and-producing-code-block)
     - [Executing command in multiline comments and producing code block](#executing-command-in-multiline-comments-and-producing-code-block)
     - [Executing command in markdown link and producing code block](#executing-command-in-markdown-link-and-producing-code-block)
+    - [Code block with transition producing code block](#code-block-with-transition-producing-code-block)
   - [Reading files contents](#reading-files-contents-1)
     - [Reading file in inline code and producing code block](#reading-file-in-inline-code-and-producing-code-block)
     - [Reading file in code blocks and producing code block](#reading-file-in-code-blocks-and-producing-code-block)
@@ -122,6 +125,17 @@ echo 'I am *markdown*'
 <!-- Debug data: (Link, Markdown, Execute) -->
 
 [> $ description](./samples/gen-md.sh)
+
+#### Code block with transition producing raw markdown
+
+```sh > $ :: which outputs:
+echo 'hello world'
+```
+
+#### Inline code with transition as a comment producing raw markdown
+
+`> $ echo 'hello world'`
+<!-- :: which outputs: -->
 
 ### Reading files contents
 
@@ -214,6 +228,12 @@ echo 'foo: true'
 <!-- Debug data: (Link, CodeBlock, Execute) -->
 
 [> yaml $ description](./samples/gen-yml.sh)
+
+#### Code block with transition producing code block
+
+```sh > txt $ :: which outputs:
+echo 'hello world'
+```
 
 ### Reading files contents
 
@@ -438,23 +458,5 @@ foo=bar
 -->
 
 ``> $ echo "\`\$foo\` is $foo"``
-
-## Transition text
-
-#### Code block with transition producing raw markdown
-
-```sh > $ :: which outputs:
-echo 'hello world'
-```
-
-#### Code block with transition producing code block
-
-```sh > txt $ :: which outputs:
-echo 'hello world'
-```
-
-#### Inline code with transition producing raw markdown
-
-`> $ echo 'hello world' :: which outputs:`
 
 The end!

--- a/spec.clear.md
+++ b/spec.clear.md
@@ -439,4 +439,22 @@ foo=bar
 
 ``> $ echo "\`\$foo\` is $foo"``
 
+## Transition text
+
+#### Code block with transition producing raw markdown
+
+```sh > $ :: which outputs:
+echo 'hello world'
+```
+
+#### Code block with transition producing code block
+
+```sh > txt $ :: which outputs:
+echo 'hello world'
+```
+
+#### Inline code with transition producing raw markdown
+
+`> $ echo 'hello world' :: which outputs:`
+
 The end!

--- a/spec.processed.md
+++ b/spec.processed.md
@@ -653,4 +653,42 @@ foo=bar
 `$foo` is bar
 <!-- END mdsh -->
 
+## Transition text
+
+#### Code block with transition producing raw markdown
+
+```sh > $ :: which outputs:
+echo 'hello world'
+```
+
+<!-- BEGIN mdsh -->
+which outputs:
+
+hello world
+<!-- END mdsh -->
+
+#### Code block with transition producing code block
+
+```sh > txt $ :: which outputs:
+echo 'hello world'
+```
+
+<!-- BEGIN mdsh -->
+which outputs:
+
+```txt
+hello world
+```
+<!-- END mdsh -->
+
+#### Inline code with transition producing raw markdown
+
+`> $ echo 'hello world' :: which outputs:`
+
+<!-- BEGIN mdsh -->
+which outputs:
+
+hello world
+<!-- END mdsh -->
+
 The end!

--- a/spec.processed.md
+++ b/spec.processed.md
@@ -18,6 +18,8 @@ in `spec.clear.md` must correspond to the same section in `spec.processed.md`.
     - [Executing command in multiline comments with data line and producing raw markdown](#executing-command-in-multiline-comments-with-data-line-and-producing-raw-markdown)
     - [Executing command in multiline comments and producing raw markdown](#executing-command-in-multiline-comments-and-producing-raw-markdown)
     - [Executing command in markdown link and producing raw markdown](#executing-command-in-markdown-link-and-producing-raw-markdown)
+    - [Code block with transition producing raw markdown](#code-block-with-transition-producing-raw-markdown)
+    - [Inline code with transition as a comment producing raw markdown](#inline-code-with-transition-as-a-comment-producing-raw-markdown)
   - [Reading files contents](#reading-files-contents)
     - [Reading file in inline code and producing raw markdown](#reading-file-in-inline-code-and-producing-raw-markdown)
     - [Reading file in code blocks and producing raw markdown](#reading-file-in-code-blocks-and-producing-raw-markdown)
@@ -34,6 +36,7 @@ in `spec.clear.md` must correspond to the same section in `spec.processed.md`.
     - [Executing command in multiline comments with data line and producing code block](#executing-command-in-multiline-comments-with-data-line-and-producing-code-block)
     - [Executing command in multiline comments and producing code block](#executing-command-in-multiline-comments-and-producing-code-block)
     - [Executing command in markdown link and producing code block](#executing-command-in-markdown-link-and-producing-code-block)
+    - [Code block with transition producing code block](#code-block-with-transition-producing-code-block)
   - [Reading files contents](#reading-files-contents-1)
     - [Reading file in inline code and producing code block](#reading-file-in-inline-code-and-producing-code-block)
     - [Reading file in code blocks and producing code block](#reading-file-in-code-blocks-and-producing-code-block)
@@ -149,6 +152,29 @@ I am *markdown*
 
 <!-- BEGIN mdsh -->
 I'm gen-md.sh
+<!-- END mdsh -->
+
+#### Code block with transition producing raw markdown
+
+```sh > $ :: which outputs:
+echo 'hello world'
+```
+
+<!-- BEGIN mdsh -->
+which outputs:
+
+hello world
+<!-- END mdsh -->
+
+#### Inline code with transition as a comment producing raw markdown
+
+`> $ echo 'hello world'`
+<!-- :: which outputs: -->
+
+<!-- BEGIN mdsh -->
+which outputs:
+
+hello world
 <!-- END mdsh -->
 
 ### Reading files contents
@@ -302,6 +328,20 @@ foo: true
 <!-- BEGIN mdsh -->
 ```yaml
 foo: bar
+```
+<!-- END mdsh -->
+
+#### Code block with transition producing code block
+
+```sh > txt $ :: which outputs:
+echo 'hello world'
+```
+
+<!-- BEGIN mdsh -->
+which outputs:
+
+```txt
+hello world
 ```
 <!-- END mdsh -->
 
@@ -651,44 +691,6 @@ foo=bar
 
 <!-- BEGIN mdsh -->
 `$foo` is bar
-<!-- END mdsh -->
-
-## Transition text
-
-#### Code block with transition producing raw markdown
-
-```sh > $ :: which outputs:
-echo 'hello world'
-```
-
-<!-- BEGIN mdsh -->
-which outputs:
-
-hello world
-<!-- END mdsh -->
-
-#### Code block with transition producing code block
-
-```sh > txt $ :: which outputs:
-echo 'hello world'
-```
-
-<!-- BEGIN mdsh -->
-which outputs:
-
-```txt
-hello world
-```
-<!-- END mdsh -->
-
-#### Inline code with transition producing raw markdown
-
-`> $ echo 'hello world' :: which outputs:`
-
-<!-- BEGIN mdsh -->
-which outputs:
-
-hello world
 <!-- END mdsh -->
 
 The end!

--- a/tests/trailing_newline.rs
+++ b/tests/trailing_newline.rs
@@ -1,0 +1,32 @@
+use std::process::Command;
+
+/// Helper: write content to a temp file, run mdsh in-place, return the result.
+fn mdsh_in_place(name: &str, content: &[u8]) -> Vec<u8> {
+    let dir = std::env::temp_dir();
+    let path = dir.join(name);
+    std::fs::write(&path, content).unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_mdsh");
+    let status = Command::new(bin)
+        .arg("--input")
+        .arg(&path)
+        .status()
+        .expect("failed to run mdsh");
+    assert!(status.success(), "mdsh exited with {status}");
+
+    std::fs::read(&path).unwrap()
+}
+
+#[test]
+fn no_mdsh_tags_with_trailing_newline_is_unchanged() {
+    let input = b"# No mdsh tags\n\nlast line\n";
+    let result = mdsh_in_place("mdsh_test_with_nl.md", input);
+    assert_eq!(result, input);
+}
+
+#[test]
+fn no_mdsh_tags_without_trailing_newline_is_unchanged() {
+    let input = b"# No mdsh tags\n\nlast line";
+    let result = mdsh_in_place("mdsh_test_without_nl.md", input);
+    assert_eq!(result, input);
+}


### PR DESCRIPTION
Fixes #98

## Summary

- Remove `trim_ascii_end` which stripped all trailing whitespace (including newlines) on in-place writes
- Normalize input with a trailing `\n` so the parser can handle every line
- Preserve the file's original trailing newline convention on output
- Add integration tests covering both trailing newline cases

## Approach

The fix is in `main.rs` (the file I/O layer) rather than the parser because:

- The parser uses chained `nom` combinators; changing it to handle EOF without `\n` would add complexity to every alternative in `markdown_piece()`
- Normalizing input at the I/O boundary is simpler and more defensive — the parser shouldn't need to worry about missing trailing newlines
- Removing `trim_ascii_end` is correct because mdsh should not modify content that isn't mdsh-related